### PR TITLE
completed a basic version of execution_context

### DIFF
--- a/src/nstd/executor/execution_context.hpp
+++ b/src/nstd/executor/execution_context.hpp
@@ -100,12 +100,13 @@ private:
         if (this->d_services.size() <= index) {
             this->d_services.resize(index + 1u);
         }
-        Service* rc(new Service(::std::forward<Args>(args)...));
+        Service* rc(new Service(*this, ::std::forward<Args>(args)...));
         this->d_services[index] = static_cast<typename Service::key_type*>(rc);
         return *rc;
     }
 
-    ::std::mutex                                            d_bottleneck;
+    mutable ::std::mutex                                    d_bottleneck;
+    bool                                                    d_running = true;
     ::std::vector<::nstd::net::execution_context::service*> d_services;
 };
 
@@ -162,6 +163,28 @@ template <typename Service>
 inline auto nstd::net::execution_context::key() -> ::std::size_t
 {
     return ::nstd::net::execution_context::get_key<typename Service::key_type>();
+}
+
+// ----------------------------------------------------------------------------
+
+template<typename Service>
+inline auto nstd::net::use_service(::nstd::net::execution_context& ctxt)
+    -> typename Service::key_type&
+    requires service<Service>
+{
+    return ctxt.use_service<Service>();
+}
+template<typename Service, typename... Args>
+inline auto nstd::net::make_service(::nstd::net::execution_context& ctxt, Args&&... args)
+    -> Service&
+{
+    return ctxt.make_service<Service>(::std::forward<Args>(args)...);
+}
+template<typename Service>
+inline auto nstd::net::has_service(::nstd::net::execution_context& ctxt)
+    -> bool
+{
+    return ctxt.has_service<Service>();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/nstd/executor/service_already_exists.cpp
+++ b/src/nstd/executor/service_already_exists.cpp
@@ -27,4 +27,7 @@
 
 // ----------------------------------------------------------------------------
 
-int service_dummy = 0;
+nstd::net::service_already_exists::service_already_exists()
+    : ::std::logic_error("service already exists")
+{
+}

--- a/src/nstd/executor/service_already_exists.hpp
+++ b/src/nstd/executor/service_already_exists.hpp
@@ -39,6 +39,8 @@ namespace nstd::net {
 class nstd::net::service_already_exists
     : public ::std::logic_error
 {
+public:
+    service_already_exists();
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
main caveat is that it only supports shutdown/destroy once. It
seems after shutdown() additional services could be added and
after destroy() it a completely clean slate - maybe.